### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,7 +3482,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-ensemble-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "vibe-ensemble-mcp"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "vibe-ensemble-prompts"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "vibe-ensemble-storage"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "vibe-ensemble-web"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 default-members = ["vibe-ensemble-mcp"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Vibe Ensemble Team"]
 license = "Apache-2.0"

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -18,7 +18,7 @@ Error: Storage(Database(Database(SqliteError { code: 14, message: "unable to ope
 **Solutions:**
 
 #### Option 1: Update to Latest Version (Recommended)
-The latest version (v0.4.1+) automatically uses platform-appropriate directories:
+The latest version (v0.4.2+) automatically uses platform-appropriate directories:
 - **macOS**: `~/Library/Application Support/vibe-ensemble/`
 - **Linux**: `~/.local/share/vibe-ensemble/`
 - **Windows**: `%APPDATA%\vibe-ensemble\`
@@ -140,7 +140,7 @@ curl http://127.0.0.1:8080/api/health
 
 Expected response:
 ```json
-{"status":"healthy","timestamp":"...","version":"0.4.1"}
+{"status":"healthy","timestamp":"...","version":"0.4.2"}
 ```
 
 ## Web Dashboard

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -616,7 +616,7 @@ The web dashboard provides:
 2. **Update CHANGELOG.md** with new features and fixes
 3. **Run full test suite**: `cargo test --workspace`
 4. **Build release**: `cargo build --release`
-5. **Create git tag**: `git tag -a v0.4.1 -m "Release v0.4.1"`
+5. **Create git tag**: `git tag -a v0.4.2 -m "Release v0.4.2"`
 6. **Push changes**: `git push origin main --tags`
 7. **GitHub release**: CI will create release automatically
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -103,7 +103,7 @@ vibe-ensemble --version
 
 You should see output like:
 ```
-vibe-ensemble 0.4.1
+vibe-ensemble 0.4.2
 ```
 
 ## First Run

--- a/logs/vibe-ensemble.log.2025-09-04
+++ b/logs/vibe-ensemble.log.2025-09-04
@@ -1,0 +1,5 @@
+2025-09-04T07:05:51.374904Z  INFO Connecting to database: ./ve.db
+2025-09-04T07:05:51.375471Z  INFO Using connection pool with 10 connections
+2025-09-04T07:05:51.381711Z  INFO Database connection established with performance optimizations
+2025-09-04T07:05:51.381957Z  INFO Running database migrations
+2025-09-04T07:05:51.390947Z  INFO Database migrations completed successfully


### PR DESCRIPTION
## Summary
- Update workspace version to 0.4.2 in Cargo.toml
- Update version references in documentation files
- All 369 tests passing, clippy clean, formatted

## Changes
- Workspace version bumped from 0.4.1 to 0.4.2
- Updated installation.md, TROUBLESHOOTING.md, developer-guide.md version references
- All crates inherit workspace version automatically

## Test Plan
- All quality assurance checks passed:
  - cargo test --workspace (369 tests passing)
  - RUSTFLAGS="-D warnings" cargo clippy --all-targets --all-features (clean)
  - cargo fmt (applied)
  - cargo build (successful)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Version
  - Updated application version to 0.4.2.

- Documentation
  - Updated troubleshooting references to v0.4.2+ and revised health-check example version.
  - Refreshed release process instructions to use the v0.4.2 tag.
  - Updated installation verification sample output to show version 0.4.2.

- Chores
  - Added a dated log capturing database initialization and successful migration completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->