### PR TITLE
docs: update CLI help text for HTTP-WebSocket upgrade and auto-discovery

### DIFF
--- a/vibe-ensemble-mcp/src/main.rs
+++ b/vibe-ensemble-mcp/src/main.rs
@@ -1,7 +1,8 @@
 //! Vibe Ensemble MCP Server - Claude Code Companion
 //!
-//! WebSocket MCP server for coordinating multiple Claude Code instances.
-//! Features WebSocket transport, SQLite database, and local web dashboard.
+//! HTTP server with WebSocket MCP upgrade for coordinating multiple Claude Code instances.
+//! Features auto-discovery ports, WebSocket MCP transport, SQLite database, and local web dashboard.
+//! Provides /ws endpoint for WebSocket upgrade and auto-discovery by Claude Code IDE integration.
 
 use clap::Parser;
 use std::env;
@@ -68,13 +69,13 @@ struct Cli {
     #[arg(long)]
     mcp_only: bool,
 
-    /// WebSocket MCP server host (default: 127.0.0.1)
+    /// HTTP server host for WebSocket MCP upgrade (default: 127.0.0.1)
     /// Environment variable: VIBE_ENSEMBLE_MCP_HOST
     #[arg(long)]
     mcp_host: Option<String>,
 
-    /// WebSocket MCP server port (default: 8081)
-    /// Environment variable: VIBE_ENSEMBLE_MCP_PORT
+    /// HTTP server port with auto-discovery fallback (default: 22360, fallback: 22361, 22362, 9090, 8081)
+    /// Provides /ws endpoint for WebSocket upgrade. Environment variable: VIBE_ENSEMBLE_MCP_PORT
     #[arg(long)]
     mcp_port: Option<u16>,
 


### PR DESCRIPTION
## Summary

Updates CLI help text to accurately reflect the new HTTP-to-WebSocket upgrade functionality with auto-discovery port fallback mechanism.

## Changes

- Updated `--mcp-port` argument description to explain HTTP server with auto-discovery fallback sequence
- Modified module documentation to reflect HTTP server architecture with WebSocket upgrade
- Clarified that the server provides `/ws` endpoint for WebSocket upgrade
- Updated port information to show fallback sequence: 22360, 22361, 22362, 9090, 8081

## Test Results

- Help text verified with `cargo run --bin vibe-ensemble -- --help`
- All quality checks passed:
  - `cargo fmt` ✅
  - `RUSTFLAGS="-D warnings" cargo clippy --all-targets --all-features` ✅  
  - `cargo test --workspace` ✅

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the server as an HTTP service with WebSocket upgrade, including the /ws endpoint.
  * Noted IDE auto-discovery support and fallback across multiple ports.
  * Updated CLI help:
    * mcp_host now refers to the HTTP upgrade endpoint host.
    * mcp_port now refers to the HTTP server port, with auto-discovery behavior and /ws upgrade details.
  * Improved descriptions for local web dashboard availability and discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->